### PR TITLE
fix: Add 'aud' claim to user-specific JWTs

### DIFF
--- a/wa_version.py
+++ b/wa_version.py
@@ -27,6 +27,7 @@ def create_user_jwt(user_id: str, jwt_secret: str) -> str:
     payload = {
         "sub": user_id,
         "role": "authenticated",
+        "aud": "authenticated",
         "iat": datetime.now(timezone.utc),
         "exp": datetime.now(timezone.utc) + timedelta(hours=1)
     }


### PR DESCRIPTION
This commit fixes a `400 Bad Request` error (`Token audience doesn't match request audience`) that occurred during user session creation.

The `create_user_jwt` function was missing the `aud` (audience) claim in the JWT payload. The Supabase Auth server requires this claim to be present and set to `'authenticated'` for the token to be considered valid.

This change adds the required `aud` claim, allowing the RLS authentication flow to work correctly.